### PR TITLE
Change hidden visibility attribute to 'collapse'.

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -519,7 +519,7 @@
     },
     "{N} Visibility Attribute": {
         "prefix": "visibility",
-        "body": "[visibility]=\"isItemVisible ? 'visible' : 'collapsed'\"$2"
+        "body": "[visibility]=\"isItemVisible ? 'visible' : 'collapse'\"$2"
     },
     "{N} Stretch Attribute": {
         "prefix": "stretch",


### PR DESCRIPTION
'Collapsed' has been deprecated in favor of 'collapse'.
https://github.com/NativeScript/NativeScript/commit/bde56872739fd70b9811b3578f5a8f5ab10b86b6#diff-7b8d7ee38393848a41171351096d9f22
http://docs.nativescript.org/api-reference/modules/_ui_enums_.visibility.html#collapse